### PR TITLE
"true" -> true in manifest.json

### DIFF
--- a/pipeline-manifest.json
+++ b/pipeline-manifest.json
@@ -388,7 +388,7 @@
 		"pattern": "sprm_outputs/(?P<region>.+)\\.ome\\.tiff-SPRM_Image_Quality_Measures.json",
 		"description": "Image Quality Measures.",
 		"edam_ontology_term": "EDAM_1.24.format_3464",
-		"is_qa_qc": "true"
+		"is_qa_qc": true
 	},
 	{
 		"pattern": "sprm_outputs/(?P<region>.+)\\.ome\\.tiff-superpixel.ome.tiff",


### PR DESCRIPTION
Looks like a typo in the manifest file.  The schema requires a boolean, and most of them just say true, but this one had the string "true".