### PR TITLE
Bound the number of samples used in silhouette_score

### DIFF
--- a/sprm/SPRM.py
+++ b/sprm/SPRM.py
@@ -169,9 +169,9 @@ def analysis(
     seg_metrics = None
     if eval_pathway:
         if options.get("image_dimension") == "3D":
-            seg_metrics = single_method_eval_3D(im, mask, output_dir)
+            seg_metrics = single_method_eval_3D(im, mask, output_dir, options)
         else:
-            seg_metrics = single_method_eval(im, mask, output_dir)
+            seg_metrics = single_method_eval(im, mask, output_dir, options)
         if eval_pathway == 1:
             # only perform evaluation on single segmentation method
             struct = {"Segmentation Evaluation Metrics v1.5": seg_metrics}

--- a/sprm/SPRM_pkg.py
+++ b/sprm/SPRM_pkg.py
@@ -42,7 +42,6 @@ from scipy.spatial import KDTree
 from skimage.feature.texture import graycomatrix, graycoprops
 from skimage.filters import threshold_otsu
 from sklearn.decomposition import NMF
-from sklearn.metrics import silhouette_score
 
 from .constants import FILENAMES_TO_IGNORE, INTEGER_PATTERN, figure_save_params
 from .data_structures import (
@@ -54,7 +53,7 @@ from .data_structures import (
 )
 from .ims_sparse_allchan import findpixelfractions
 from .ims_sparse_allchan import reallocateIMS as reallo
-from .wrapped_functions import PCA, TSNE, UMAP, KMeans
+from .wrapped_functions import PCA, TSNE, UMAP, KMeans, bounded_silhouette_score
 
 """
 
@@ -572,7 +571,7 @@ def cell_cluster(
                 cluster_list.append(cellbycluster)
 
                 try:
-                    score = silhouette_score(cell_matrix, preds)
+                    score = bounded_silhouette_score(cell_matrix, preds, options)
                 except ValueError as e:
                     LOGGER.exception("silhouette_score failed")
                     score = -math.inf
@@ -2080,7 +2079,7 @@ def voxel_cluster(im: IMGstruct, options: Dict) -> np.ndarray:
     #         preds = voxelbycluster.fit_predict(channvals_random)
     #         cluster_list.append(voxelbycluster)
     #
-    #         score = silhouette_score(channvals_random, preds)
+    #         score = bounded_silhouette_score(channvals_random, preds, options)
     #         cluster_score.append(score)
     #
     #     max_value = max(cluster_score)

--- a/sprm/modules/preprocessing.py
+++ b/sprm/modules/preprocessing.py
@@ -57,6 +57,58 @@ def _ensure_cell_centers(core_data: CoreData, output_dir: Path):
     centers_df.to_csv(centers_path, index_label="ID")
 
 
+def build_legacy_options(options: Optional[Union[Path, str, Dict]] = None) -> Dict[str, Any]:
+    """
+    Build a legacy options dictionary from the provided options parameter.
+
+    This is used to maintain compatibility with older code that expects a flat options dict.
+
+    Parameters
+    ----------
+    options : Path, str, dict, or None, default None
+        Options for preprocessing. Can be:
+        - Path/str to options.txt file (will be read)
+        - Dictionary of options (already loaded)
+        - None (use defaults)
+    Returns
+    -------
+    Dict[str, Any]: A flat dictionary of options with defaults applied.
+    """
+    if options is None:
+        return {
+            "image_dimension": "2D",
+            "debug": False,
+            "interior_cells_only": 1,
+            "valid_cell_threshold": 10,
+        }
+    elif isinstance(options, (str, Path)):
+        print(f"Reading options from: {options}")
+        options_dict = dict(read_options(Path(options)))
+        # Set defaults for missing fields
+        if "image_dimension" not in options_dict:
+            options_dict["image_dimension"] = "2D"
+        if "debug" not in options_dict:
+            options_dict["debug"] = False
+        if "interior_cells_only" not in options_dict:
+            options_dict["interior_cells_only"] = 1
+        if "valid_cell_threshold" not in options_dict:
+            options_dict["valid_cell_threshold"] = 10
+        return options_dict
+    elif isinstance(options, dict):
+        # Set defaults for missing fields
+        if "image_dimension" not in options:
+            options["image_dimension"] = "2D"
+        if "debug" not in options:
+            options["debug"] = False
+        if "interior_cells_only" not in options:
+            options["interior_cells_only"] = 1
+        if "valid_cell_threshold" not in options:
+            options["valid_cell_threshold"] = 10
+        return options
+    else:
+        raise TypeError(f"options must be None, Path, str, or dict, got {type(options)}")
+
+
 def run(
     img_file: Union[Path, str],
     mask_file: Union[Path, str],
@@ -118,36 +170,7 @@ def run(
     print("=" * 60)
 
     # Handle options parameter
-    if options is None:
-        # Create minimal options dict with defaults
-        options = {
-            "image_dimension": image_dimension,
-            "debug": debug,
-            "interior_cells_only": 1,  # Default behavior
-            "valid_cell_threshold": 10,  # Minimum valid cells
-        }
-    elif isinstance(options, (str, Path)):
-        # Read options from file
-        print(f"Reading options from: {options}")
-        options = dict(read_options(Path(options)))
-        # Override with function parameters if provided
-        if image_dimension != "2D":
-            options["image_dimension"] = image_dimension
-        if debug:
-            options["debug"] = debug
-    elif isinstance(options, dict):
-        # Use provided options dict directly
-        # Set defaults for required fields if not present
-        if "image_dimension" not in options:
-            options["image_dimension"] = image_dimension
-        if "debug" not in options:
-            options["debug"] = debug
-        if "interior_cells_only" not in options:
-            options["interior_cells_only"] = 1
-        if "valid_cell_threshold" not in options:
-            options["valid_cell_threshold"] = 10
-    else:
-        raise TypeError(f"options must be None, Path, str, or dict, got {type(options)}")
+    options = build_legacy_options(options)
 
     # Load image and mask
     print(f"Reading image file: {img_file.name}")

--- a/sprm/modules/segmentation_eval.py
+++ b/sprm/modules/segmentation_eval.py
@@ -11,6 +11,8 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Union
 
+from .preprocessing import build_legacy_options
+
 from ..single_method_eval import single_method_eval
 from ..single_method_eval_3D import single_method_eval_3D
 from ..SPRM_pkg import NumpyEncoder
@@ -87,10 +89,11 @@ def run(
     # Run appropriate evaluation based on dimension
     print(f"Computing segmentation metrics ({image_dimension})...")
     with _force_sprm_pickle_from_source_tree():
+        options = build_legacy_options()
         if image_dimension == "3D":
-            eval_result = single_method_eval_3D(im, mask, output_dir)
+            eval_result = single_method_eval_3D(im, mask, output_dir, options)
         else:
-            eval_result = single_method_eval(im, mask, output_dir)
+            eval_result = single_method_eval(im, mask, output_dir, options)
 
     # The legacy evaluators return a tuple:
     # (metrics_dict, fraction_background, inv_background_cv, background_pca)

--- a/sprm/options-3D.txt
+++ b/sprm/options-3D.txt
@@ -1,2 +1,3 @@
 run_outlinePCA 0
 image_dimension 3D
+silhouette_samples_break 50000

--- a/sprm/options.txt
+++ b/sprm/options.txt
@@ -38,4 +38,4 @@ adj_matrix_delta 3
 image_dimension 2D
 apng_delay 100
 subtype_thresh 0.1
-silhouette_max_samples 100000
+silhouette_samples_break 50000

--- a/sprm/options.txt
+++ b/sprm/options.txt
@@ -38,3 +38,4 @@ adj_matrix_delta 3
 image_dimension 2D
 apng_delay 100
 subtype_thresh 0.1
+silhouette_max_samples 100000

--- a/sprm/outlinePCA.py
+++ b/sprm/outlinePCA.py
@@ -11,11 +11,11 @@ from scipy import interpolate, stats
 from shapely.geometry import Polygon
 from shapely.geometry.polygon import orient
 from skimage import measure
-from sklearn.metrics import pairwise_distances_argmin_min, silhouette_score
+from sklearn.metrics import pairwise_distances_argmin_min
 
 from .constants import figure_save_params
 from .data_structures import MaskStruct
-from .wrapped_functions import PCA, KMeans
+from .wrapped_functions import PCA, KMeans, bounded_silhouette_score
 
 """
 
@@ -43,7 +43,7 @@ def shape_cluster(cell_matrix, typelist, all_clusters, s, options, output_dir, i
             preds = cellbycluster.fit_predict(cell_matrix)
             cluster_list.append(cellbycluster)
 
-            score = silhouette_score(cell_matrix, preds)
+            score = bounded_silhouette_score(cell_matrix, preds, options)
             cluster_score.append(score)
 
         max_value = max(cluster_score)
@@ -248,7 +248,7 @@ def pca_cluster_shape(features, polyg, output_dir, options):
 def kmeans_cluster_shape(shape_vector, outline_vectors, output_dir, options):
     fig = plt.figure()
     num_cluster, kmeans_labels, cluster_centers = get_silhouette_score(
-        shape_vector, "PCs-outlines-cluster-silhouette-scores", output_dir
+        shape_vector, "PCs-outlines-cluster-silhouette-scores", output_dir, options
     )
     # rgb
     phi = np.linspace(0, 2 * np.pi, num_cluster + 1)
@@ -822,7 +822,7 @@ def showshapesbycluster(mask, nseg, cellbycluster, filename):
         plt.savefig(f"{filename}-cellshapescluster{k}.pdf", **figure_save_params)
 
 
-def get_silhouette_score(d, s, o):
+def get_silhouette_score(d, s, o, options):
     n = np.arange(2, 11)
     silhouette_avg = []
     for num_clusters in n:
@@ -832,7 +832,7 @@ def get_silhouette_score(d, s, o):
         cluster_labels = kmeans.labels_
 
         # silhouette score
-        silhouette_avg.append(silhouette_score(d, cluster_labels))
+        silhouette_avg.append(bounded_silhouette_score(d, cluster_labels, options))
 
     plt.plot(n, silhouette_avg, "bx-")
     plt.xlabel("Number of Clusters")

--- a/sprm/single_method_eval.py
+++ b/sprm/single_method_eval.py
@@ -19,11 +19,10 @@ from scipy.stats import variation
 from skimage.filters import threshold_mean
 from skimage.morphology import area_closing, closing, disk
 from skimage.segmentation import morphological_geodesic_active_contour as MorphGAC
-from sklearn.metrics import silhouette_score
 from sklearn.preprocessing import StandardScaler
 from threadpoolctl import threadpool_info
 
-from .wrapped_functions import PCA, KMeans
+from .wrapped_functions import PCA, KMeans, bounded_silhouette_score
 
 """
 Companion to SPRM.py
@@ -329,7 +328,7 @@ def cell_type(mask, img, bestz):
     return label_list
 
 
-def cell_uniformity(mask, img, bestz, label_list):
+def cell_uniformity(mask, img, bestz, label_list, options):
     cell_coord = get_indices_sparse(mask)[1:]
     cell_coord_num = len(cell_coord)
     ss = StandardScaler()
@@ -378,7 +377,9 @@ def cell_uniformity(mask, img, bestz, label_list):
                 if n_labels < 2 or n_labels >= n_samples:
                     silhouette.append(0.0)
                 else:
-                    silhouette.append(float(silhouette_score(feature_matrix_z, labels)))
+                    silhouette.append(
+                        float(bounded_silhouette_score(feature_matrix_z, labels, options))
+                    )
             except Exception as excp:
                 LOGGER.warn(
                     f"cell_uniformity: silhouette_score failed for c={c}: {excp}; using 0.0"
@@ -509,7 +510,9 @@ def get_quality_score(features, model):
     return score if np.isfinite(score) else 0.0
 
 
-def single_method_eval(img, mask, output_dir: Path) -> Tuple[Dict[str, Any], float, float]:
+def single_method_eval(
+    img, mask, output_dir: Path, options: Dict[str, Any]
+) -> Tuple[Dict[str, Any], float, float]:
     print("Calculating single-method metrics v1.5 for", img.path)
     # get best z slice for future use
     bestz = mask.bestz
@@ -654,7 +657,7 @@ def single_method_eval(img, mask, output_dir: Path) -> Tuple[Dict[str, Any], flo
             # img_channels = np.squeeze(img.data[0, 0, :, bestz, :, :], axis=0)
             # get cell uniformity
             cell_CV, cell_fraction, cell_silhouette = cell_uniformity(
-                current_mask, img, bestz, cell_type_labels
+                current_mask, img, bestz, cell_type_labels, options
             )
             avg_cell_CV = np.average(cell_CV)
             avg_cell_fraction = np.average(cell_fraction)

--- a/sprm/single_method_eval_3D.py
+++ b/sprm/single_method_eval_3D.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Tuple
 
 import numpy as np
 import xmltodict
-from sklearn.metrics import silhouette_score
 from sklearn.preprocessing import StandardScaler
 
 from .single_method_eval import (
@@ -22,7 +21,7 @@ from .single_method_eval import (
     uniformity_CV,
     weighted_by_cluster,
 )
-from .wrapped_functions import PCA, KMeans
+from .wrapped_functions import PCA, KMeans, bounded_silhouette_score
 
 """
 Companion to SPRM.py
@@ -109,7 +108,7 @@ def cell_type(mask, channels):
     return label_list
 
 
-def cell_uniformity(mask, channels, label_list):
+def cell_uniformity(mask, channels, label_list, options):
     n = len(channels)
     cell_coord = get_indices_sparse(mask)[1:]
     cell_coord_num = len(cell_coord)
@@ -147,7 +146,7 @@ def cell_uniformity(mask, channels, label_list):
         if c == 1:
             silhouette.append(1)
         else:
-            silhouette.append(silhouette_score(feature_matrix_z, labels))
+            silhouette.append(bounded_silhouette_score(feature_matrix_z, labels, options))
         for i in range(c):
             cluster_feature_matrix = feature_matrix[np.where(labels == i)[0], :]
             cluster_feature_matrix_z = feature_matrix_z[np.where(labels == i)[0], :]
@@ -158,7 +157,9 @@ def cell_uniformity(mask, channels, label_list):
     return CV, fraction, silhouette[1:]
 
 
-def single_method_eval_3D(img, mask, output_dir: Path) -> Tuple[Dict[str, Any], float, float]:
+def single_method_eval_3D(
+    img, mask, output_dir: Path, options: Dict[str, Any]
+) -> Tuple[Dict[str, Any], float, float]:
     if not img.data:
         raise NotImplementedError("Not implemented for disk-based images")
     print("Calculating single-method metrics 3D v1.5 for", img.path)
@@ -269,7 +270,7 @@ def single_method_eval_3D(img, mask, output_dir: Path) -> Tuple[Dict[str, Any], 
         else:
             # get cell uniformity
             cell_CV, cell_fraction, cell_silhouette = cell_uniformity(
-                current_mask, img_channels, cell_type_labels
+                current_mask, img_channels, cell_type_labels, options
             )
             avg_cell_CV = np.average(cell_CV)
             avg_cell_fraction = np.average(cell_fraction)

--- a/sprm/wrapped_functions.py
+++ b/sprm/wrapped_functions.py
@@ -105,13 +105,14 @@ def _silhouette_scaled_sample_count(cell_matrix, options):
     Return the number of samples to use for silhouette_score, based on the
     value specified in options and the input matrix length.
     """
-    n0 = options.get("silhouette_sample_break", None)
+    n0 = options.get("silhouette_samples_break", None)
     if not n0 or n0 >= cell_matrix.shape[0]:
         return None  # no need to restrict samples
     else:
-        alpha = 1.0/(1.0 + cell_matrix.shape[0] - n0)
-        n = ((alpha * cell_matrix.shape[0])
-             + (1.0 - alpha) * (n0 + np.sqrt(float(cell_matrix.shape[0] - n0))))
+        alpha = 1.0 / (1.0 + cell_matrix.shape[0] - n0)
+        n = (alpha * cell_matrix.shape[0]) + (1.0 - alpha) * (
+            n0 + np.sqrt(float(cell_matrix.shape[0] - n0))
+        )
         return int(n)
 
 
@@ -121,6 +122,10 @@ def bounded_silhouette_score(cell_matrix, preds, options):
     specified in options is less than the input matrix length.
     """
     if n_samples := _silhouette_scaled_sample_count(cell_matrix, options):
+        LOGGER.debug(
+            f"bounded_silhouette_score: reducing {cell_matrix.shape[0]} to {n_samples} samples"
+        )
         return silhouette_score(cell_matrix, preds, sample_size=n_samples)
     else:
+        LOGGER.debug(f"bounded_silhouette_score: using full {cell_matrix.shape[0]} samples")
         return silhouette_score(cell_matrix, preds)

--- a/sprm/wrapped_functions.py
+++ b/sprm/wrapped_functions.py
@@ -100,13 +100,27 @@ def silhouette_score(x, labels, *argv, **argc):
     return rslt
 
 
+def _silhouette_scaled_sample_count(cell_matrix, options):
+    """
+    Return the number of samples to use for silhouette_score, based on the
+    value specified in options and the input matrix length.
+    """
+    n0 = options.get("silhouette_sample_break", None)
+    if not n0 or n0 >= cell_matrix.shape[0]:
+        return None  # no need to restrict samples
+    else:
+        alpha = 1.0/(1.0 + cell_matrix.shape[0] - n0)
+        n = ((alpha * cell_matrix.shape[0])
+             + (1.0 - alpha) * (n0 + np.sqrt(float(cell_matrix.shape[0] - n0))))
+        return int(n)
+
+
 def bounded_silhouette_score(cell_matrix, preds, options):
     """
     Run silhouette_score, restricting the number of samples if the value
     specified in options is less than the input matrix length.
     """
-    max_samples = options.get("silhouette_max_samples", None)
-    if max_samples and max_samples < cell_matrix.shape[0]:
-        return silhouette_score(cell_matrix, preds, sample_size=max_samples)
+    if n_samples := _silhouette_scaled_sample_count(cell_matrix, options):
+        return silhouette_score(cell_matrix, preds, sample_size=n_samples)
     else:
         return silhouette_score(cell_matrix, preds)

--- a/sprm/wrapped_functions.py
+++ b/sprm/wrapped_functions.py
@@ -1,6 +1,7 @@
 import logging
 
 from frozendict import frozendict
+import numpy as np
 from sklearn.cluster import KMeans as KMeans_raw
 
 # from sklearn.cluster import MiniBatchKMeans as KMeans_raw

--- a/sprm/wrapped_functions.py
+++ b/sprm/wrapped_functions.py
@@ -6,6 +6,7 @@ from sklearn.cluster import KMeans as KMeans_raw
 # from sklearn.cluster import MiniBatchKMeans as KMeans_raw
 from sklearn.decomposition import PCA as PCA_raw
 from sklearn.manifold import TSNE as TSNE_raw
+from sklearn.metrics import silhouette_score as silhouette_score_raw
 from umap import UMAP as UMAP_raw
 
 LOGGER = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ ADDL_OPTS = frozendict()
 UMAP_ADDL_OPTS = ADDL_OPTS
 PCA_ADDL_OPTS = ADDL_OPTS
 KMEANS_ADDL_OPTS = ADDL_OPTS
+SILHOUETTE_ADDL_OPTS = ADDL_OPTS
 
 
 def UMAP(*argv, **argc):
@@ -87,3 +89,24 @@ def TSNE(*argv, **argc):
     my_argc = dict(KMEANS_ADDL_OPTS)
     my_argc.update(argc)
     return TSNE_raw(*argv, **my_argc)
+
+
+def silhouette_score(x, labels, *argv, **argc):
+    my_argc = dict(SILHOUETTE_ADDL_OPTS)
+    my_argc.update(argc)
+    LOGGER.debug(f"silhouette_score begin {x.shape} {x.dtype}")
+    rslt = silhouette_score_raw(x, labels, *argv, **my_argc)
+    LOGGER.debug(f"silhouette_score end: {rslt}")
+    return rslt
+
+
+def bounded_silhouette_score(cell_matrix, preds, options):
+    """
+    Run silhouette_score, restricting the number of samples if the value
+    specified in options is less than the input matrix length.
+    """
+    max_samples = options.get("silhouette_max_samples", None)
+    if max_samples and max_samples < cell_matrix.shape[0]:
+        return silhouette_score(cell_matrix, preds, sample_size=max_samples)
+    else:
+        return silhouette_score(cell_matrix, preds)


### PR DESCRIPTION
It turns out that the sklearn.metrics.silhouette_score() routine scales very poorly with large numbers of samples.  This is a cause of a lot of the run time in the latter half of the execution of SPRM.  This PR:
* Adds a parameter to options.txt to set a scaling limit on the number of samples
* Introduces bounded_silhouette_score(), which uses that scaling limit. All samples are used below the scaling limit, but above the limit the curve bends over to scale like the square root of the number of samples.  The blending function isn't great but it's C1 continuous.
* Adds handling of options to some routines that need options to call the bounded_silhouette_score function, including in the sprm/modules subdirectory .