### PR TITLE
Fix-Refactor/3D-single-method-metrics

### DIFF
--- a/sprm/SPRM.py
+++ b/sprm/SPRM.py
@@ -87,7 +87,10 @@ def get_cell_blk_sz(num_cells: int, im: IMGstruct, options: Dict[str, Any]) -> i
     many cells should be calculated in each block of the calculation?
     This function provides a way to balance memory use and run time.
     """
-    return num_cells // 10  # TODO: make a smarter calculation
+    configured = options.get("feature_cell_block_size")
+    if configured:
+        return max(1, int(configured))
+    return max(1, min(500, num_cells // 10))  # TODO: make a smarter calculation
 
 
 def analysis(
@@ -319,14 +322,29 @@ def analysis(
             total_vector = build_vector(im, mask, len(inCell_set), j, total_vector)
 
             LOGGER.debug(f"for {t} {j} masked_imgs_coord is {len(masked_imgs_coord)}")
+            progress_path = output_dir / (baseoutputfilename + "-feature_progress.tsv")
+            if not progress_path.exists():
+                with open(progress_path, "w") as progress_file:
+                    progress_file.write(
+                        "time_s\ttimepoint\tmask_channel\tblock_start\tblock_end\tcell_count\n"
+                    )
             mic_iter = masked_imgs_coord.subset_iter(inCell_set)
             for blk_min in range(0, len(inCell_set), cell_blk_sz):
+                block_start_time = time.monotonic()
                 indexed_mic_this_block = itertools.islice(mic_iter, 0, cell_blk_sz)
                 ordered_indices = []
                 mic_list = []
                 for ii, cell_arr in indexed_mic_this_block:
                     ordered_indices.append(ii)
                     mic_list.append(cell_arr)
+                if not mic_list:
+                    continue
+                block_end = blk_min + len(mic_list)
+                print(
+                    f"Feature block start: t={t} mask_channel={j} "
+                    f"cells={blk_min}:{block_end} block_size={len(mic_list)}",
+                    flush=True,
+                )
                 index_trans_tbl = {ii: elt for ii, elt in enumerate(ordered_indices)}
                 ROI_dict = calculations(mic_list, im, t, bestz)
 
@@ -345,6 +363,16 @@ def analysis(
                     covar_matrix[t, j, cell_idx + blk_min, :, :] = cov_m
                     mean_vector[t, j, cell_idx + blk_min, :, :] = mu_v
                     total_vector[t, j, cell_idx + blk_min, :, :] = total
+                block_dt = time.monotonic() - block_start_time
+                print(
+                    f"Feature block done: t={t} mask_channel={j} "
+                    f"cells={blk_min}:{block_end} elapsed_s={block_dt:.1f}",
+                    flush=True,
+                )
+                with open(progress_path, "a") as progress_file:
+                    progress_file.write(
+                        f"{block_dt:.3f}\t{t}\t{j}\t{blk_min}\t{block_end}\t{len(mic_list)}\n"
+                    )
 
             LOGGER.debug(
                 f"cell stats info: covar_matrix {covar_matrix.shape} {covar_matrix.dtype}"
@@ -384,9 +412,6 @@ def analysis(
                 np.int32
             ),
         )
-        ROI_coords = None
-        mask.set_ROI(ROI_coords)
-
         cell_analysis(
             im=im,
             mask=mask,

--- a/sprm/SPRM_pkg.py
+++ b/sprm/SPRM_pkg.py
@@ -1973,46 +1973,62 @@ def SNR(im: IMGstruct, filename: str, output_dir: Path, inCells: list, options: 
     zlist = []
     channelist = []
     snr_channels_list = []
+    bins = np.arange(256, dtype=np.float64)
     for ch_idx in range(im.img.dims.C):
-        all_pix = np.concatenate(
-            [im.get_plane(ch_idx, z_idx).copy() for z_idx in range(im.img.dims.Z)], axis=None
-        )
-        LOGGER.debug(f"all_pix is {all_pix.shape} {all_pix.dtype}")
-        all_pix = np.nan_to_num(all_pix, nan=0.0, posinf=0.0, neginf=0.0).astype(
-            np.float32, copy=False
-        )
+        hist = np.zeros(256, dtype=np.int64)
+        for z_idx in range(im.img.dims.Z):
+            plane = im.get_plane(ch_idx, z_idx)
+            plane = np.nan_to_num(plane, nan=0.0, posinf=255.0, neginf=0.0)
+            plane = np.clip(plane, 0, 255).astype(np.uint8, copy=False)
+            hist += np.bincount(plane.reshape(-1), minlength=256)
 
-        mean = float(all_pix.mean()) if all_pix.size else 0.0
-        std = float(all_pix.std(ddof=0)) if all_pix.size else 0.0
-        snr = mean / std if std > 0 else 0.0
-        snr_channels_list.append(snr if np.isfinite(snr) else 0.0)
-
-        # Robust Otsu-like foreground/background ratio (avoid NaN ranges / empty slices)
-        if all_pix.size == 0 or float(np.var(all_pix)) == 0.0:
+        count = int(hist.sum())
+        LOGGER.debug(f"histogrammed {count} pixels for channel {ch_idx}")
+        if count == 0:
+            snr_channels_list.append(0.0)
             channelist.append(0.0)
             continue
 
-        max_img = float(np.max(all_pix))
+        total = float(np.dot(hist, bins))
+        mean = total / count
+        variance = float(np.dot(hist, bins * bins)) / count - mean * mean
+        std = float(np.sqrt(max(variance, 0.0)))
+        snr = mean / std if std > 0 else 0.0
+        snr_channels_list.append(snr if np.isfinite(snr) else 0.0)
+
+        # Robust Otsu-like foreground/background ratio from the histogram.
+        if variance == 0.0:
+            channelist.append(0.0)
+            continue
+
+        nonzero_bins = np.flatnonzero(hist)
+        max_img = float(nonzero_bins[-1]) if nonzero_bins.size else 0.0
         if (not np.isfinite(max_img)) or max_img <= 0.0:
             channelist.append(0.0)
             continue
 
-        # Scale into a stable range for thresholding (uint16-ish), but keep float for skimage.
-        scale = 65535.0 / max_img
-        img_scaled = np.nan_to_num(all_pix * scale, nan=0.0, posinf=0.0, neginf=0.0)
+        weights_1 = np.cumsum(hist).astype(np.float64)
+        weights_2 = count - weights_1
+        means_1 = np.divide(
+            np.cumsum(hist * bins),
+            weights_1,
+            out=np.zeros_like(weights_1),
+            where=weights_1 > 0,
+        )
+        reverse_weighted = np.cumsum((hist * bins)[::-1])[::-1]
+        means_2 = np.divide(
+            reverse_weighted,
+            weights_2,
+            out=np.zeros_like(weights_2),
+            where=weights_2 > 0,
+        )
+        between = weights_1[:-1] * weights_2[:-1] * (means_1[:-1] - means_2[:-1]) ** 2
+        thresh = int(np.argmax(between)) if between.size else 0
 
-        try:
-            thresh = float(threshold_otsu(img_scaled))
-        except Exception as excp:
-            print(
-                f"SNR: threshold_otsu failed for channel {ch_idx}: {excp}; using median threshold"
-            )
-            thresh = float(np.median(img_scaled))
-
-        fg = img_scaled[img_scaled > thresh]
-        bg = img_scaled[img_scaled <= thresh]
-        mean_a = float(fg.mean()) if fg.size else 0.0
-        mean_b = float(bg.mean()) if bg.size else 0.0
+        fg_count = int(hist[thresh + 1 :].sum())
+        bg_count = int(hist[: thresh + 1].sum())
+        mean_a = float(np.dot(hist[thresh + 1 :], bins[thresh + 1 :]) / fg_count) if fg_count else 0.0
+        mean_b = float(np.dot(hist[: thresh + 1], bins[: thresh + 1]) / bg_count) if bg_count else 0.0
         fbr = (mean_a / mean_b) if mean_b > 0 else 0.0
         channelist.append(fbr if np.isfinite(fbr) else 0.0)
 
@@ -3622,15 +3638,24 @@ def quality_measures_3D(
 
         bestz = mask.get_bestz()
         ROI_coords = mask.get_ROI()
+        if ROI_coords is None:
+            raise RuntimeError(
+                "quality_measures_3D requires mask ROI coordinates; run get_coordinates() "
+                "and mask.set_ROI() before calling it."
+            )
 
         im_data = im.get_data()
         im_dims = im_data.shape
+        channel_data = im_data[0, 0, :, :, :, :]
+        pixels = im_dims[-3] * im_dims[-2] * im_dims[-1]
 
-        im_channels = im_data[0, 0, :, bestz, :, :]
-        pixels = im_dims[-2] * im_dims[-1]
-        bgpixels = ROI_coords[0][0]
-        cells = ROI_coords[0][1:]
-        nuclei = ROI_coords[1][1:]
+        cell_coords = np.concatenate(
+            [arr for arr in ROI_coords[0].cells_only_iter()], axis=1
+        ).astype(np.int32, copy=False)
+        nuclei_coords = np.concatenate(
+            [arr for arr in ROI_coords[1].cells_only_iter()], axis=1
+        ).astype(np.int32, copy=False)
+        bgpixel_count = pixels - cell_coords.shape[1]
 
         # Image Quality Metrics that require cell segmentation
         struct["Image Quality Metrics that require cell segmentation"] = dict()
@@ -3644,18 +3669,7 @@ def quality_measures_3D(
         # get cytoplasm coords
         # cytoplasm = find_cytoplasm(ROI_coords)
 
-        # dims are z c y x
-        total_intensity_per_chan = im_channels
-        total_intensity_per_chan = np.reshape(
-            total_intensity_per_chan,
-            (
-                total_intensity_per_chan.shape[1],
-                total_intensity_per_chan.shape[0]
-                * total_intensity_per_chan.shape[2]
-                * total_intensity_per_chan.shape[3],
-            ),
-        )
-        total_intensity_per_chan = np.sum(total_intensity_per_chan, axis=1)
+        total_intensity_per_chan = np.sum(channel_data, axis=(1, 2, 3))
 
         # check / filter out 1-D coords - hot fix
         # cytoplasm_ndims = [x.ndim for x in cytoplasm]
@@ -3664,35 +3678,18 @@ def quality_measures_3D(
         #
         # cytoplasm = np.delete(cytoplasm, idx_ndims).tolist()
 
-        # cell total intensity per channel
-        # total_intensity_path = output_dir / (img_name + '-cell_channel_total.csv')
-        # total_intensity_file = get_paths(total_intensity_path)
-        # total_intensity = pd.read_csv(total_intensity_file[0]).to_numpy()
-        total_intensity_cell = np.concatenate(cells, axis=1)
-        total_intensity_per_chancell = np.sum(
-            im_channels[
-                total_intensity_cell[0], :, total_intensity_cell[1], total_intensity_cell[2]
-            ],
-            axis=0,
-        )
-        # total_intensity_per_chancell = np.sum(total_intensity[:, 1:], axis=0)
-
-        total_intensity_per_chanbg = np.sum(
-            im_channels[bgpixels[0], :, bgpixels[1], bgpixels[2]], axis=0
+        total_intensity_per_chancell = np.asarray(
+            [
+                channel_data[ch, cell_coords[0], cell_coords[1], cell_coords[2]].sum()
+                for ch in range(channel_data.shape[0])
+            ]
         )
 
-        # total_intensity_nuclei_path = output_dir / (img_name + '-nuclei_channel_total.csv')
-        # total_intensity_nuclei_file = get_paths(total_intensity_nuclei_path)
-        # total_intensity_nuclei = pd.read_csv(total_intensity_nuclei_file[0]).to_numpy()
-        # total_intensity_nuclei_per_chan = np.sum(total_intensity_nuclei[:, 1:], axis=0)
-
-        # nuclei total intensity per channel
-        total_intensity_nuclei = np.concatenate(nuclei, axis=1)
-        total_intensity_nuclei_per_chan = np.sum(
-            im_channels[
-                total_intensity_nuclei[0], :, total_intensity_nuclei[1], total_intensity_nuclei[2]
-            ],
-            axis=0,
+        total_intensity_nuclei_per_chan = np.asarray(
+            [
+                channel_data[ch, nuclei_coords[0], nuclei_coords[1], nuclei_coords[2]].sum()
+                for ch in range(channel_data.shape[0])
+            ]
         )
 
         # cytoplasm total intensity per channel
@@ -3703,9 +3700,17 @@ def quality_measures_3D(
         nuc_cell_avgR = total_intensity_nuclei_per_chan / total_intensity_per_chancell
 
         if options.get("normalize_bg"):
+            bgpixels = ROI_coords[0].background()
+            total_intensity_per_chanbg = np.asarray(
+                [
+                    channel_data[ch, bgpixels[0], bgpixels[1], bgpixels[2]].sum()
+                    for ch in range(channel_data.shape[0])
+                ]
+            )
+            bgpixel_count = bgpixels.shape[1]
             cell_bg_avgR = (
                 total_intensity_per_chancell
-                / (total_intensity_per_chanbg / bgpixels.shape[1])
+                / (total_intensity_per_chanbg / bgpixel_count)
                 / cell_total[i]
             )
         else:
@@ -3752,10 +3757,10 @@ def quality_measures_3D(
         struct["Image Quality Metrics that require cell segmentation"]["Number of Cells"] = (
             cell_total[i]
         )
-        # struct["Number of Background Pixels"] = bgpixels.shape[1]
+        # struct["Number of Background Pixels"] = bgpixel_count
         struct["Image Quality Metrics that require cell segmentation"][
             "Fraction of Image Occupied by Cells"
-        ] = (pixels - bgpixels.shape[1]) / pixels
+        ] = (pixels - bgpixel_count) / pixels
 
         struct["Image Quality Metrics not requiring image segmentation"][
             "Total Intensity"
@@ -3879,6 +3884,12 @@ def reallocate_and_merge_intensities(
         im.set_channel_labels(channel_list)
 
     # prune for NaNs
+    if options.get("skip_nan_scan"):
+        return
+
+    if im.get_data is None or getattr(im, "data", None) is None:
+        return
+
     nan_count = 0
     for c_idx, z_idx, slice in im.get_img_channel_generator():
         nan_count += np.isnan(slice).sum()

--- a/sprm/data_structures.py
+++ b/sprm/data_structures.py
@@ -91,25 +91,32 @@ class CellTable3D:
     def __init__(self, mask: MaskStruct, cidx: int):
         s, t, c, z, y, x = mask.get_data().shape
         assert all([dim == 1 for dim in [s, t]]), "bad mask shape"
-        vol = mask.get_data()[0, 0, 0, :, :, :]
-        indices = np.indices(vol.shape).astype(np.int32)
-        recs = np.rec.fromarrays(
-            [vol, indices[2], indices[1], indices[0]], names="cellid, x, y, z"
-        )
-        recs = recs.reshape(-1)
-        LOGGER.debug(f"recs is {recs.shape} {recs.dtype}")
-        LOGGER.debug(
-            f"maxes: {np.max(recs['cellid'])} {np.max(recs['x'])}"
-            f" {np.max(recs['y'])} {np.max(recs['z'])}"
-        )
-        recs.sort(kind="heapsort", order=["cellid", "z", "y", "x"])
-        LOGGER.debug(
-            f"maxes: {np.max(recs['cellid'])} {np.max(recs['x'])}"
-            f" {np.max(recs['y'])} {np.max(recs['z'])}"
-        )
-        entries, counts = np.unique(recs["cellid"], return_counts=True)
-        self.counts = np.stack((entries, counts), axis=1).copy()
-        self.vals = np.vstack((recs["z"], recs["y"], recs["x"])).copy()
+        vol = mask.get_data()[0, 0, cidx, :, :, :]
+        self._background_shape = vol.shape
+        self._background_mask = vol == 0
+
+        flat = vol.reshape(-1)
+        foreground_idx = np.flatnonzero(flat)
+        if foreground_idx.size == 0:
+            self.counts = np.array([[0, 0]], dtype=np.int64)
+            self.vals = np.zeros((3, 0), dtype=np.int32)
+            return
+
+        labels = flat[foreground_idx]
+        order = np.argsort(labels, kind="stable")
+        labels = labels[order]
+        foreground_idx = foreground_idx[order]
+
+        entries, counts = np.unique(labels, return_counts=True)
+        background = np.array([[0, 0]], dtype=np.int64)
+        self.counts = np.vstack((background, np.stack((entries, counts), axis=1))).copy()
+
+        yyxx = self._background_shape[1] * self._background_shape[2]
+        zs = (foreground_idx // yyxx).astype(np.int32, copy=False)
+        rem = foreground_idx % yyxx
+        ys = (rem // self._background_shape[2]).astype(np.int32, copy=False)
+        xs = (rem % self._background_shape[2]).astype(np.int32, copy=False)
+        self.vals = np.vstack((zs, ys, xs)).copy()
 
     def __iter__(self):
         cell_offset = 0
@@ -128,7 +135,7 @@ class CellTable3D:
         """
         Like cell_iter but excludes the background "cell" at index 0
         """
-        return itertools.islice(self.cell_iter(), 1)
+        return itertools.islice(self.cell_iter(), 1, None)
 
     def subset_iter(self, restriction_set: set):
         """
@@ -141,7 +148,7 @@ class CellTable3D:
                 yield cell_id, cell_mtx
 
     def background(self):
-        return self.vals[:, 0 : self.counts[0]]
+        return np.vstack(np.nonzero(self._background_mask)).astype(np.int32, copy=False)
 
     def __len__(self):
         return len(self.counts)


### PR DESCRIPTION
fix: Fix 3D single-method metrics: background coords, SNR, and quality_measures_3D

CellTable3D.background() crashed with "only integer scalar arrays can be
converted to a scalar index" because it sliced with self.counts[0] (the
[cell_id, count] row) instead of a scalar. Rework CellTable3D to store a
background mask at construction and return (3, N) voxel coordinates, and
fix the analogous 2D CellTable.background() to use self.counts[0][1].
This unblocks normalize_background / quality_control on 3D IMC data.

Quality of life updates:

- SNR: compute mean/std and Otsu foreground-background ratio from a 256-bin
  histogram streamed per z-plane instead of concatenating all pixels,
  avoiding large allocations on big 3D stacks.
- quality_measures_3D: drive cell/nucleus/background intensities from the
  CellTable3D iterators and full voxel volume rather than best-z slices and
  raw ROI index arrays; guard against missing ROI coords.
- SPRM.py: keep mask ROI coords available for quality_measures_3D, make the
  feature-cell block size configurable (feature_cell_block_size) and bounded,
  and emit per-block feature progress to stdout and a -feature_progress.tsv.
- reallocate_and_merge_intensities: allow skipping the NaN scan
  (skip_nan_scan) and no-op when image data is absent.