### PR TITLE
Add pattern for zipped Zarr store in manifest

### DIFF
--- a/pipeline-manifest.json
+++ b/pipeline-manifest.json
@@ -486,7 +486,7 @@
 		"is_data_product":  true
 	},
 	{
-		"pattern": ".*sprm_output.zarr.zip/",
+		"pattern": ".*sprm_output.zarr.zip",
 		"description": "zipped Zarr store containing serialized SpatialData object",
 		"edam_ontology_term": "EDAM_1.24.format_3987",
 		"is_data_product":  true

--- a/pipeline-manifest.json
+++ b/pipeline-manifest.json
@@ -486,6 +486,12 @@
 		"is_data_product":  true
 	},
 	{
+		"pattern": ".*sprm_output.zarr.zip/",
+		"description": "zipped Zarr store containing serialized SpatialData object",
+		"edam_ontology_term": "EDAM_1.24.format_3987",
+		"is_data_product":  true
+	},
+	{
 		"pattern": "out.hdf5",
 		"description": "hdf5 file containing DataFrames for each of SPRM's CSV outputs, including expression values, cluster assignments",
 		"edam_ontology_term": "EDAM_1.24.format_3590",


### PR DESCRIPTION
As we zip more zarr stores to reduce file counts, manifests must be updated so that those stores are recognized.